### PR TITLE
Fix ChartLegendContent display name

### DIFF
--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -314,7 +314,7 @@ const ChartLegendContent = React.forwardRef<
     );
   }
 );
-ChartLegendContent.displayName = 'ChartLegend';
+ChartLegendContent.displayName = 'ChartLegendContent';
 
 // Helper to extract item config from a payload.
 function getPayloadConfigFromPayload(


### PR DESCRIPTION
## Summary
- correct `ChartLegendContent.displayName` string

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683fb9e138a0832f956f7d1e8ac8542b