### PR TITLE
Fix toast effect listener

### DIFF
--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, []);
+  }, [setState]);
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- prevent duplicate toast listener subscriptions by depending on `setState`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683fb9e66194832f9008062cda6f4244