### PR TITLE
ci(workflows): update deploy-pages to v5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,4 +66,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary
- update `actions/deploy-pages` from `v4` to `v5` in the GitHub Pages deployment workflow
- address the GitHub Actions Node.js 20 deprecation warning by moving to the action version that runs on Node 24
- keep the existing Pages build and deploy flow unchanged apart from the runtime-compatible action version

## Changes
| File | Change |
|------|--------|
| `.github/workflows/deploy.yml` | Bumped `actions/deploy-pages` from `v4` to `v5` |

## Testing
- Not run (workflow-only change)