### PR TITLE
ci(workflows): avoid deprecated Node 20 action runtime warnings

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -51,10 +51,16 @@ jobs:
       - name: Build project
         run: npm run build
 
+      - name: Archive Pages artifact
+        run: tar --dereference --hard-dereference --directory ./out -cvf "$RUNNER_TEMP/artifact.tar" --exclude=.git --exclude=.github .
+
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-artifact@v6
         with:
-          path: ./out
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- upgrade workflow actions that still run on the deprecated Node 20 JavaScript runtime
- replace the Pages artifact wrapper with an explicit artifact upload so the workflow no longer pulls in upload-artifact v4 indirectly
- keep the project Node version unchanged because the warning is about action runtime compatibility, not the app toolchain

## Changes
| File | Change |
|------|--------|
| `.github/workflows/deploy.yml` | bumped `actions/checkout` to `v5`, `actions/setup-node` to `v6`, and replaced the Pages artifact upload wrapper with explicit `actions/upload-artifact@v6` usage |

## Testing
- Not run (workflow-only change)